### PR TITLE
Added conditional statement for browsers with JSON issue

### DIFF
--- a/js/treehouse.js
+++ b/js/treehouse.js
@@ -161,7 +161,7 @@ $.ajax({
     },
     // If ajax succeeds
     success: function (data) {
-        var dObj = JSON.parse(data);
+        var dObj = (typeof data === "string") ?  JSON.parse(data) : data;
         var latest = reverseSortObject(dObj.points);
         $(".treehouse-badges").append('<h1>I have passed ' + dObj.badges.length + ' lessons and scored ' + numberWithCommas(dObj.points.total) + ' points at Treehouse!</h1><p>Check out some of my last passed course content at the badges below: </p>');
         generateTreehouseBadges(dObj.badges.reverse());


### PR DESCRIPTION
I came up with a fix for browsers that read the returned ajax data as text instead of an object.
Set the ajax data to a variable with a conditional that if data is text then use `JSON.parse(data)` otherwise simply pass the data.
I have tested this on WaterFox and PaleMoon (the 2 browsers with the known issues) as well as vanilla FireFox, Chrome and IE10 and it all works nicely.
